### PR TITLE
KPMP-60: Fixed IE parent overflow bug in CSS when no children are pre…

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -72,7 +72,10 @@
 }
 
 .fine-uploader-dropzone-container {
-	min-height: 100px !important;
+    min-height: 100px !important;
+    & .react-fine-uploader-gallery-files {
+        overflow-y: visible;
+    }
 }
 
 .react-fine-uploader-gallery-dropzone-content {


### PR DESCRIPTION
Fixed IE parent overflow bug in CSS when no children are present.

Could not duplicate issue where Open File Dialog was appearing behind the browser window. Please provide OS, browser version, and any other diagnostic data if the problem is reproducible.

Thanks,
Brian Royer