### PR TITLE
KPMP-87: Fixes button positioning in IE.

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -61,13 +61,6 @@
 	}
 }
 
-.buttonRow {
-	padding-top: 15px;
-	position: fixed;
-	bottom: 15px;
-	width: 100%;
-}
-
 .modalTitle {
 	font-weight: 700;
 	font-size: 18px;
@@ -92,9 +85,21 @@
 }
 
 .uploadFilesModal {
-	.modal-content {
-		min-height: 750px;
-	}
+	& .modal-content {
+        min-height: 750px;
+        height: 750px;
+    }
+    & .uploadFilesContainer {
+        height: 100%;
+    }
+    & .buttonRow {
+        padding-top: 15px;
+        position: absolute;
+        border-top: 1px solid #e5e5e5;
+        left: 0;
+        bottom: 15px;
+        width: 100%;
+    }
 }
 
 .fileProgressModal {


### PR DESCRIPTION
Internet explorer seems to prefer absolute positioning nestled below a relative parent. The parent also had to fill up the entire space of the modal, thus the chain inherits 100% all the way down after filling to 750px.